### PR TITLE
Fix editor starter kit manifest with updated beta version for @minecraft/server

### DIFF
--- a/assets/behavior/manifest.json
+++ b/assets/behavior/manifest.json
@@ -24,7 +24,7 @@
     },
     {
       "module_name": "@minecraft/server",
-      "version": "1.0.0-beta"
+      "version": "1.1.0-beta"
     }
   ]
 }


### PR DESCRIPTION
Starter kit extensions were failing due to an invalid module after the 1.0.0 release earlier this month. Fixing the default manifest.