### PR TITLE
[BUGFIX] Missing capabilities in manifest - prevents pack stripping at export

### DIFF
--- a/assets/behavior/manifest.json
+++ b/assets/behavior/manifest.json
@@ -17,6 +17,9 @@
       "entry": "scripts/{MC_EXTENSION_NAME}.js"
     }
   ],
+  "capabilities": [
+    "editorExtension"
+  ],
   "dependencies": [
     {
       "module_name": "@minecraft/server-editor",

--- a/assets/resource/manifest.json
+++ b/assets/resource/manifest.json
@@ -7,6 +7,9 @@
     "version": [ 0, 0, 1 ],
     "min_engine_version": [ 1, 14, 0 ]
   },
+  "capabilities": [
+    "editorExtension"
+  ],
   "modules": [
     {
       "description": "{MC_EXTENSION_NAME} Resource Module",


### PR DESCRIPTION
Extension kit extensions are missing the editor capabilities section of the manifest.
When exporting an editor project, the extensions were not correctly baked into the .mcproject file and removed when exporting a world.