### PR TITLE
Add back support for watch mode in starter kit

### DIFF
--- a/README.md
+++ b/README.md
@@ -220,6 +220,13 @@ The only time you should ever need to restart Minecraft is if you add any new as
 ```
 > You'll see the Editor quickly disappear and reload, and !voila! - your newly changed script will have been loaded.  Try it out to confirm!
 
+To facilitate development, you can also place your compilation into watch mode as well. To do this, run
+```bash
+npm run build -- --watch
+```
+
+This will have your build monitor for changes to any typescript files. When changes are detected, it will automatically recompile and redeploy the files, so that when you reload from within game it picks up your changes automatically.
+
 &nbsp;
 
 ### Debugging with output

--- a/payload/webpack.config.js
+++ b/payload/webpack.config.js
@@ -6,10 +6,11 @@ const { webpack, DefinePlugin, SourceMapDevToolPlugin } = require('webpack');
 const ExtensionName = envHelpers.getExtensionName();
 const BehaviorPackName = envHelpers.getBehaviorPackName();
 
-module.exports = {
+module.exports = (_, argv) => ({
     entry: './src/index.ts',
     mode: 'development',
     devtool: false,
+    watch: argv.watch,
     output: {
         path: path.resolve(__dirname, 'dist'),
         filename: ExtensionName + '.js',
@@ -35,11 +36,11 @@ module.exports = {
     plugins: [
         new DefinePlugin({
             __EXTENSION_NAME__: JSON.stringify(ExtensionName),
-            __BEHAVIOR_PACK_NAME__: JSON.stringify(BehaviorPackName)
+            __BEHAVIOR_PACK_NAME__: JSON.stringify(BehaviorPackName),
         }),
         new SourceMapDevToolPlugin({
             filename: `${ExtensionName}.js.map`,
             moduleFilenameTemplate: '[absolute-resource-path]',
         }),
-    ]
-};
+    ],
+});


### PR DESCRIPTION
Restructure the build task so that the copy happens as a follow up to webpack compilation. This allows us to support watch mode again, and also works out of the box for multiple drives because of how we do the copy.