### PR TITLE
User Story AB#1037294: Fixed sample-icon loading

### DIFF
--- a/templates/src/extension-full/Extension.ts
+++ b/templates/src/extension-full/Extension.ts
@@ -367,7 +367,7 @@ import {
     return uiSession.toolRail.addTool({
         displayStringLocId: 'portalGenerator.displayName',
         displayString: 'Portal Generator (CTRL + SHIFT + P)',
-        icon: 'pack://textures/editor/sample-icon.png',
+        icon: 'pack://textures/editor/Sample-icon.png',
         tooltipLocId: 'portalGenerator.toolTip',
         tooltip: 'Creates portals',
     });


### PR DESCRIPTION
Sample icon had the wrong name for the portal generator extension.

![image](https://github.com/Mojang/EditorExtensionStarterKit/assets/73849941/d808c2dd-d9eb-4dc2-9d3f-4cee3afa3def)
